### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,4 +49,4 @@ jobs:
         run: poetry run pytest . --cov --cov-report=xml
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Reverts nasa-gcn/gcn-classic-to-kafka#91. See https://github.com/codecov/codecov-action/issues/1293.